### PR TITLE
Added decache to fix caching issues with child dependencies

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -1,5 +1,6 @@
 import path from 'path';
 const loader = require('../index').default;
+jest.mock('decache');
 const { operator } = require('../index');
 
 describe('js-to-styles-vars-loader', () => {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const decache = require('decache');
 
 const requireReg = /require\s*\(['|"](.+)['|"]\)(?:\.([^;\s]+))?[;\s]/g;
 
@@ -37,7 +38,7 @@ const operator = {
     getVarData (modulePath, webpackContext) {
         return modulePath.reduce( (accumulator, currentPath) => {
             const modulePath = path.join(webpackContext.context, currentPath.path);
-            delete require.cache[require.resolve(modulePath)];
+            decache(modulePath);
             const moduleData = (currentPath.methodName)? require(modulePath)[currentPath.methodName] : require(modulePath);
             webpackContext.addDependency(modulePath);
             return Object.assign(accumulator, moduleData);

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "babel-preset-es2015": "^6.24.0",
     "coveralls": "^2.12.0",
     "jest": "^19.0.2"
+  },
+  "dependencies": {
+    "decache": "^4.1.0"
   }
 }


### PR DESCRIPTION
Hey there,
I ended up still having issues with webpack caching the loaded js modules, preventing proper webpack watch reloading.
The `delete require.cache[require.resolve(modulePath)];` didn't clear the cache of any child dependencies in `modulePath`, but `decache` seems to be a relatively popular library that does just that.