### PR TITLE
adds options.type override

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Debug Jest",
+            // "preLaunchTask": "Jest watch",
+            // "postDebugTask": "",
+            "port": 9229,
+            "protocol": "inspector",
+            // "trace": true
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Probably you use [sass-loader](https://github.com/webpack-contrib/sass-loader) o
 For sass-loader:
 ```js
 {
-  rules: [
+  rules: [{
     test: /\.scss$/,
     use: [
       {
@@ -37,7 +37,7 @@ For sass-loader:
         loader: "js-to-styles-var-loader"
       }
     ]
-  ]
+  }]
 }
 ```
 
@@ -45,7 +45,7 @@ For less-loader:
 
 ```js
 {
-  rules: [
+  rules: [{
     test: /\.less$/,
     use: [
       {
@@ -61,9 +61,28 @@ For less-loader:
         loader: "js-to-styles-var-loader"
       }
     ]
-  ]
+  }]
 }
 ```
+
+Specify type:
+```js
+{
+  rules: [{
+    test: /\.less$/,
+    use: [
+      "less-loader",
+      {
+        loader : "js-to-styles-var-loader",
+        options: {
+          type: "less"
+        }
+      }
+    ]
+  }]
+}
+```
+
 #### Usage
 
 Let's assume we would like to store some variable data in a module like this:

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -31,11 +31,18 @@ describe('js-to-styles-vars-loader', () => {
             expect(operator.getPreprocessorType).toHaveBeenCalledWith({ resource: context._module.resource });
         });
 
+        it('calls operator.mergeVarsToContent with content and loader context, and custom preprocessor type', () => {
+            const customLessContext = {...context, options: { type: 'less', }}
+
+            spyOn(operator, 'mergeVarsToContent');
+            loader.call(customLessContext, 'asdf');
+            expect(operator.mergeVarsToContent).toHaveBeenCalledWith('asdf', customLessContext, 'less');
+        })
+
         it('calls operator.mergeVarsToContent with content and loader context, and preprocessor type', () => {
             spyOn(operator, 'mergeVarsToContent');
             loader.call(context, 'asdf');
             expect(operator.mergeVarsToContent).toHaveBeenCalledWith('asdf', context, 'sass');
-
         });
 
         it('handles .sass extension for sass files', () => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const decache = require('decache');
 const squba = require('squba')
+const getOptions = require('loader-utils').getOptions
 
 const requireReg = /require\s*\((["'])([\w.\/]+)(?:\1)\)((?:\.[\w_-]+)*);?/igm;
 
@@ -127,8 +128,16 @@ exports.operator = operator;
 
 const loader = function (content) {
     const webpackContext = this;
-    const resource = operator.getResource(webpackContext);
-    const preprocessorType = operator.getPreprocessorType({ resource });
+    // const options = getOptions(this);
+    let preprocessorType
+
+    if(this.options && this.options.type) {
+        preprocessorType = this.options.type
+    } else {
+        const resource = operator.getResource(webpackContext);
+        preprocessorType = operator.getPreprocessorType({ resource });
+    }
+
     const merged = operator.mergeVarsToContent(content, webpackContext, preprocessorType);
     return merged;
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest --config jest.config",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --config jest.config",
     "test:coverage": "jest --config jest.config --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test:watch": "jest --watch --config jest.config"
   },


### PR DESCRIPTION
I'm using Semantic UI Less, and because some of the files processed by less do not contain .less as the extension, the plugin doesn't work for me as expected.

I must import the variables here: https://glitch.com/edit/equinox-motion?path=ui/styles/semantic.less:15:17 so that your loader will know what type of variables to create.

But due to the load order, I need to import the variables here: https://glitch.com/edit/#!/equinox-motion?path=ui/styles/site/globals/site.variables:1 so that they actually override the defaults.

I expect that I will be able to move the require statements to the .variables file and update webpack.config to

```
{
  loader: "js-to-styles-var-loader",
  options: { type: 'less' }, 
}
```