### PR TITLE
Add integration with vue-laoder

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,11 +109,11 @@ const operator = {
         const preProcs = [
             {
                 type: 'sass',
-                reg: /\.scss$|\.sass$/
+                reg: /\.scss$|\.sass$|\.vue\?.*?lang=scss|\.vue\?.*?lang=sass/
             },
             {
                 type: 'less',
-                reg: /\.less$/
+                reg: /\.less$|\.vue\?.*?lang=less/
             }
         ];
 


### PR DESCRIPTION
The new RegExps consider styles loaded from Vue components. They have this presentation `'\Desktop\vue-project\src\index.vue?vue&type=style&index=0&id=2964abc9&scoped=true&lang=less&'` which breaks preprocessor type detection